### PR TITLE
chore: remove uncessary array instanciation

### DIFF
--- a/src/components/NutrientCalc/NutrientCalc.jsx
+++ b/src/components/NutrientCalc/NutrientCalc.jsx
@@ -121,7 +121,7 @@ function NutrientCalc({
 
   // display states
   const [displayBrix, setDisplayBrix] = useState("0");
-  const [yeastNames, setYeastNames] = useState([{}]);
+  const [yeastNames, setYeastNames] = useState({});
   const [selectedBrand, setSelectedBrand] = useState([
     {
       selectedBrand: "Lalvin",
@@ -138,7 +138,7 @@ function NutrientCalc({
     },
   ]);
   const selectedYeastObj = selectedYeast[0];
-  const yeastObj = yeastNames[0];
+  const yeastObj = yeastNames;
 
   // gets yeasts from json data
   useEffect(() => {
@@ -146,7 +146,7 @@ function NutrientCalc({
       try {
         const response = JSON.parse(JSON.stringify(yeasts));
         const data = response;
-        setYeastNames([data]);
+        setYeastNames(data);
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
From react 18 API reference it is not necessary to wrap a single object in an array for the initial state.

https://react.dev/reference/react/useState