### PR TITLE
fix: prevent scrollbar jitter and overflow x

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,11 @@
   }
 }
 
+html {
+  overflow-x: hidden;
+  width: 100vw;
+}
+
 
 /* sets up page */
 .main-div-style {


### PR DESCRIPTION
On the current site when you click the various Toolbar options it shifts the main page to the side when the scrollbar pops up.

Also, some of the pages have a way-ward element that breaches the horizontal bounds of the page which creates a horizontal scroll bar that does not serve any purpose.

These two lines of code prevent the page from jittering when the scrollbar pops up and it hides the horizontal scroll bar.